### PR TITLE
ignore typescript 5.0 export type *

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ make sure to use [ @typescript-eslint/parser](https://github.com/typescript-esli
 
   `caseSensitive` - if `true`, enforce properties to be in case-sensitive order. Default is `true`.
 
-  `natural` - if `true`, enforce properties to be in natural order. Default is false. Natural Order compares strings containing combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number `3` in Natural Sorting.
+  `natural` - if `true`, enforce properties to be in natural order. Default is false. Natural Order compares strings containing a combination of letters and numbers in the way a human being would sort. It basically sorts numerically, instead of sorting alphabetically. So the number 10 comes after the number `3` in Natural Sorting.
 
   ```
   Standard sorting:   Natural order sorting:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Often it makes sense to enable `sort-export-all` only for certain files/director
 }
 ```
 
+If you use TypeScript,
+make sure to use [ @typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint) as parser for better compatability.
+
 ## Rule configuration
 
 - The 1st option is `"asc"` or `"desc"`.

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -100,3 +100,40 @@ tester.run("sort-export-all", sortExportAll, {
     },
   ],
 });
+
+const typescriptTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
+  parserOptions: { ecmaVersion: 2015, sourceType: "module" },
+});
+
+typescriptTester.run("sort-export-all", sortExportAll, {
+  valid: [
+    {
+      code: `
+      export * from './constants';
+      export type * from './types';
+      export * from './utils';
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      export * from './utils';
+      export type * from './types';
+      export * from './constants';
+    `,
+      errors: [
+        {
+          message:
+            "\"export * from './constants'\" should occur before \"export * from './utils'\".",
+        },
+      ],
+      output: `
+      export * from './constants';
+      export type * from './types';
+      export * from './utils';
+    `,
+    },
+  ],
+});

--- a/src/rules/sort-export-all.ts
+++ b/src/rules/sort-export-all.ts
@@ -78,6 +78,11 @@ export const sortExportAll: Rule.RuleModule = {
         if (node.type !== "ExportAllDeclaration") {
           return;
         }
+        // This ignores cases like `export type *` in TypeScript 5.0
+        // It assumes we use @typescript-eslint/parser parser
+        if ("exportKind" in node && node.exportKind === "type") {
+          return;
+        }
         if (
           prevNode != null &&
           typeof node.source.value === "string" &&


### PR DESCRIPTION
This PR ignore typescript 5.0 `export type *` (requires `@typescript-eslint/eslint-plugin` to be the parser)

It also includes:

- update README.md
- fix readme typo

closes https://github.com/nirtamir2/eslint-plugin-sort-export-all/issues/16
