### PR TITLE
Fix incomplete sort

### DIFF
--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -194,5 +194,20 @@ run({
         export * from "./c";
       `,
     },
+    // {
+    //   name: "should handle comment",
+    //   code: ts`
+    //     // This is C
+    //     export * from "./c";
+    //     export * from "./b";
+    //     export * from "./a";
+    //   `,
+    //   output: ts`
+    //     export * from "./a";
+    //     export * from "./b";
+    //     // This is C
+    //     export * from "./c";
+    //   `,
+    // },
   ],
 });

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -43,6 +43,22 @@ run({
       `,
       errors: [
         {
+          message:
+            "\"export * from './a'\" should occur before \"export * from './b'\".",
+        },
+      ],
+    },
+    {
+      code: js`
+        export * from "./b";
+        export * from "./a";
+      `,
+      output: js`
+        export * from "./a";
+        export * from "./b";
+      `,
+      errors: [
+        {
           messageId: "unorderedSortExportAll",
           data: {
             beforeName: "./a",

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -140,33 +140,18 @@ run({
         export * from "./utils";
       `,
     },
-    //  TODO: Fix make this test pass
-    // {
-    //   code: ts`
-    //     export * from "./lib/ticker-wat/Wat";
-    //     export * from "./lib/sticky-wat/Wat";
-    //     export * from "./lib/client-wat/Wat";
-    //     export * from "./lib/ticker-wat/Wat";
-    //     export * from "./lib/custom-wat/Wat";
-    //     export * from "./lib/rules-wat/Wat";
-    //     export * from "./lib/send-wat/Wat";
-    //     export * from "./assets/timezone";
-    //     export * from "./hooks/useWat";
-    //     export * from "./lib/avatar/Avatar";
-    //   `,
-    //
-    //   output: ts`
-    //     export * from "./assets/timezone";
-    //     export * from "./hooks/useWat";
-    //     export * from "./lib/avatar/Avatar";
-    //     export * from "./lib/client-wat/Wat";
-    //     export * from "./lib/custom-wat/Wat";
-    //     export * from "./lib/rules-wat/Wat";
-    //     export * from "./lib/send-wat/Wat";
-    //     export * from "./lib/sticky-wat/Wat";
-    //     export * from "./lib/ticker-wat/Wat";
-    //     export * from "./lib/ticker-wat/Wat";
-    //   `,
-    // },
+    {
+      code: ts`
+        export * from "./b";
+        export * from "./a";
+        export * from "./c";
+      `,
+
+      output: ts`
+        export * from "./a";
+        export * from "./c";
+        export * from "./b";
+      `,
+    },
   ],
 });

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -37,16 +37,19 @@ run({
         export * from "./b";
         export * from "./a";
       `,
-      errors: [
-        {
-          message:
-            "\"export * from './a'\" should occur before \"export * from './b'\".",
-        },
-      ],
       output: js`
         export * from "./a";
         export * from "./b";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./a",
+            afterName: "./b",
+          },
+        },
+      ],
     },
     {
       code: js`
@@ -54,17 +57,20 @@ run({
         export * from "./a";
         export * from "./c";
       `,
-      errors: [
-        {
-          message:
-            "\"export * from './a'\" should occur before \"export * from './b'\".",
-        },
-      ],
       output: js`
         export * from "./a";
         export * from "./b";
         export * from "./c";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./a",
+            afterName: "./b",
+          },
+        },
+      ],
     },
     {
       code: js`
@@ -72,33 +78,39 @@ run({
         export * from "./c";
         export * from "./b";
       `,
-      errors: [
-        {
-          message:
-            "\"export * from './b'\" should occur before \"export * from './c'\".",
-        },
-      ],
       output: js`
         export * from "./a";
         export * from "./b";
         export * from "./c";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./b",
+            afterName: "./c",
+          },
+        },
+      ],
     },
     {
       code: js`
         export * from "./ca/cb";
         export * from "./a";
       `,
-      errors: [
-        {
-          message:
-            "\"export * from './a'\" should occur before \"export * from './ca/cb'\".",
-        },
-      ],
       output: js`
         export * from "./a";
         export * from "./ca/cb";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./a",
+            afterName: "./ca/cb",
+          },
+        },
+      ],
     },
   ],
 });
@@ -128,17 +140,20 @@ run({
         export type * from "./types";
         export * from "./constants";
       `,
-      errors: [
-        {
-          message:
-            "\"export * from './constants'\" should occur before \"export * from './utils'\".",
-        },
-      ],
       output: ts`
         export * from "./constants";
         export type * from "./types";
         export * from "./utils";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./constants",
+            afterName: "./utils",
+          },
+        },
+      ],
     },
     {
       name: "should handle duplicate names",
@@ -153,6 +168,15 @@ run({
         export * from "./b";
         export * from "./b";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./a",
+            afterName: "./b",
+          },
+        },
+      ],
     },
     {
       name: "should handle duplicate names (issue)",
@@ -193,6 +217,15 @@ run({
         export * from "./b";
         export * from "./c";
       `,
+      errors: [
+        {
+          messageId: "unorderedSortExportAll",
+          data: {
+            beforeName: "./a",
+            afterName: "./c",
+          },
+        },
+      ],
     },
     // {
     //   name: "should handle comment",

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -141,10 +141,51 @@ run({
       `,
     },
     {
+      name: "should handle duplicate names",
       code: ts`
         export * from "./b";
         export * from "./a";
+        export * from "./b";
+      `,
+
+      output: ts`
+        export * from "./a";
+        export * from "./b";
+        export * from "./b";
+      `,
+    },
+    {
+      name: "should handle duplicate names (issue)",
+      code: ts`
+        export * from "./lib/ticker-wat/Wat";
+        export * from "./lib/sticky-wat/Wat";
+        export * from "./lib/client-wat/Wat";
+        export * from "./lib/custom-wat/Wat";
+        export * from "./lib/rules-wat/Wat";
+        export * from "./lib/send-wat/Wat";
+        export * from "./assets/timezone";
+        export * from "./hooks/useWat";
+        export * from "./lib/avatar/Avatar";
+      `,
+
+      output: ts`
+        export * from "./assets/timezone";
+        export * from "./hooks/useWat";
+        export * from "./lib/avatar/Avatar";
+        export * from "./lib/client-wat/Wat";
+        export * from "./lib/custom-wat/Wat";
+        export * from "./lib/rules-wat/Wat";
+        export * from "./lib/send-wat/Wat";
+        export * from "./lib/sticky-wat/Wat";
+        export * from "./lib/ticker-wat/Wat";
+      `,
+    },
+    {
+      name: "should handle multiple fixes",
+      code: ts`
         export * from "./c";
+        export * from "./b";
+        export * from "./a";
       `,
 
       output: ts`

--- a/src/rules/sort-export-all.test.ts
+++ b/src/rules/sort-export-all.test.ts
@@ -149,8 +149,8 @@ run({
 
       output: ts`
         export * from "./a";
-        export * from "./c";
         export * from "./b";
+        export * from "./c";
       `,
     },
   ],

--- a/src/rules/sort-export-all.ts
+++ b/src/rules/sort-export-all.ts
@@ -103,12 +103,12 @@ export default createEslintRule<Options, MessageIds>({
         });
 
         for (const [index, sortedNode] of sortedNodes.entries()) {
-          if (nodes[index] === sortedNode) {
+          const node = nodes[index];
+          if (node == null) {
             continue;
           }
 
-          const node = nodes[index];
-          if (node == null) {
+          if (node.source.value === sortedNode.source.value) {
             continue;
           }
 

--- a/src/rules/sort-export-all.ts
+++ b/src/rules/sort-export-all.ts
@@ -48,7 +48,7 @@ export default createEslintRule<Options, MessageIds>({
     },
     messages: {
       unorderedSortExportAll:
-        "\"export * from '{{thisName}}'\" should occur before \"export * from '{{prevName}}'\".",
+        "\"export * from '{{beforeName}}'\" should occur before \"export * from '{{afterName}}'\".",
     },
     schema: [
       {
@@ -112,16 +112,16 @@ export default createEslintRule<Options, MessageIds>({
             continue;
           }
 
-          const thisName = sortedNode.source.value;
-          const prevName = node.source.value;
-          if (isValidOrder(thisName, prevName)) {
+          const beforeName = sortedNode.source.value;
+          const afterName = node.source.value;
+          if (isValidOrder(beforeName, afterName)) {
             context.report({
               messageId: "unorderedSortExportAll",
               node: sortedNode,
               ...(sortedNode.loc === null ? null : { loc: sortedNode.loc }),
               data: {
-                thisName,
-                prevName,
+                beforeName,
+                afterName,
               },
               fix(fixer) {
                 if (node == null) return null;

--- a/src/rules/sort-export-all.ts
+++ b/src/rules/sort-export-all.ts
@@ -111,7 +111,7 @@ export default createEslintRule<Options, MessageIds>({
               fix(fixer) {
                 if (prevNode == null) return null;
                 const fixes: Array<RuleFix> = [];
-                const sourceCode = context.getSourceCode();
+                const { sourceCode } = context;
                 const moveExportAllDeclaration = (
                   fromNode: TSESTree.ExportAllDeclaration,
                   toNode: TSESTree.ExportAllDeclaration,


### PR DESCRIPTION
This PR fixes #9 and changes the implementation of sorting `export *`. 
It gathers all the exports and then puts them in the right place. 